### PR TITLE
Prevent PHP warning `invalid argument`

### DIFF
--- a/classes/Admin/Page/Help.php
+++ b/classes/Admin/Page/Help.php
@@ -96,7 +96,11 @@ class AC_Admin_Page_Help extends AC_Admin_Page {
 
 		$columns = array();
 		foreach ( AC()->get_list_screens() as $ls ) {
-			foreach ( $ls->get_column_types() as $column ) {
+			$column_types = $ls->get_column_types();
+			if ( ! $column_types ) {
+				continue;
+			}
+			foreach ( $column_types as $column ) {
 				$columns[ $column->get_type() ] = $column->get_type();
 			}
 		}


### PR DESCRIPTION
Related: https://github.com/codepress/admin-columns-issues/issues/1002

`Warning: Invalid argument supplied for foreach() in /wp-content/plugins/admin-columns-pro/admin-columns/classes/Admin/Page/Help.php on line 103`

Another solution would be to parse as an array within `AC_ListScreen::get_column_types()`