### PR TITLE
fix: do not force showing notices with hidden class

### DIFF
--- a/src/scss/admin-general.scss
+++ b/src/scss/admin-general.scss
@@ -154,7 +154,7 @@ body.settings_page_codepress-admin-columns {
 	}
 
 	#cpac {
-		.notice {
+		.notice:not(.hidden) {
 			display: block;
 		}
 	}


### PR DESCRIPTION
## Summary

Your implementation to always show notices also shows notices from other plugins.

### Actual Behavior

All notices (also hidden) from other vendors are always visible.

### Steps to reproduce

- Install https://wordpress.org/plugins/real-media-library-lite/
- Navigate to your Admin Column settings page

Real Media Library shows a notice for failing WP REST API requests (using the WP Core class `.hidden`).

![image](https://user-images.githubusercontent.com/1008534/135765031-4835a9fa-768a-405e-8ed5-7b1c22847794.png)

### Proposal

Do not force showing notices with explicit `.hidden` class.

### Environment

Not relevant.
